### PR TITLE
Update miniconda (and thus python) version.

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:4.12.0
+FROM continuumio/miniconda3:22.11.1
 
 RUN apt-get --allow-releaseinfo-change update && \
      rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Previous version did not support match syntax in daf_butler.